### PR TITLE
fix small syntax error from merge

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -98,12 +98,7 @@ function App() {
             }
           ></Route>
           <Route path='*' element={<ErrorComponent resetError={resetError} />} />
-        </Routes>
-              />
-            }
-          ></Route>
-        </Routes>
-      )}
+        </Routes>)}
     </div>
   )
 }


### PR DESCRIPTION
What I did: 
deleted extra `<Route>` tags from the bottom of the code.  I missed this earlier when resolving the merge conflict.  

Type of change:

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

What's next?
responsive design, proptypes, and cypress testing.  If there's time, look into that error when we click the forward buttons to reset the error. 